### PR TITLE
Added new page for Early Cancer Diagnosis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "lucide-react": "^0.525.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^7.14.2",
         "react-scripts": "5.0.1",
         "recharts": "^3.1.0",
         "styled-components": "^6.1.19",
@@ -15291,6 +15292,57 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -16292,6 +16344,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lucide-react": "^0.525.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^7.14.2",
     "react-scripts": "5.0.1",
     "recharts": "^3.1.0",
     "styled-components": "^6.1.19",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,28 @@
 import React from 'react';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { FingertipsProvider } from './context/FingertipsContext';
 import Fingertips from './pages/Fingertips/Fingertips';
+import { sections } from './config/sections';
 import './App.css';
+
+const basename = process.env.PUBLIC_URL || '/';
 
 function App() {
   return (
     <FingertipsProvider>
-      <div className="App">
-        <Fingertips />
-      </div>
+      <BrowserRouter basename={basename}>
+        <div className="App">
+          <Routes>
+            <Route path="/" element={<Navigate to="/cyp" replace />} />
+            <Route path="/cyp" element={<Fingertips section={sections.cyp} />} />
+            <Route
+              path="/early-cancer"
+              element={<Fingertips section={sections['early-cancer']} />}
+            />
+            <Route path="*" element={<Navigate to="/cyp" replace />} />
+          </Routes>
+        </div>
+      </BrowserRouter>
     </FingertipsProvider>
   );
 }

--- a/src/config/sections.ts
+++ b/src/config/sections.ts
@@ -1,0 +1,39 @@
+import { colors, colorsRGB } from '../theme/colors';
+
+export type SectionId = 'cyp' | 'early-cancer';
+
+export interface SectionConfig {
+  id: SectionId;
+  path: string;
+  navLabel: string;
+  mainTitle: string;
+  subtitle: string;
+  backgroundColor: string;
+  accentColor: string;
+  accentColorRgb: string;
+}
+
+export const sections: Record<SectionId, SectionConfig> = {
+  cyp: {
+    id: 'cyp',
+    path: '/cyp',
+    navLabel: 'Children & Young People',
+    mainTitle: 'Edge Health',
+    subtitle: 'Children & Young People Health',
+    backgroundColor: colors.secondary.lightPink,
+    accentColor: colors.primary.pink,
+    accentColorRgb: colorsRGB.pink,
+  },
+  'early-cancer': {
+    id: 'early-cancer',
+    path: '/early-cancer',
+    navLabel: 'Early Cancer Diagnosis',
+    mainTitle: 'Edge Health',
+    subtitle: 'Early Cancer Diagnosis',
+    backgroundColor: colors.secondary.lightCyan,
+    accentColor: colors.secondary.aquamarine,
+    accentColorRgb: colorsRGB.aquamarine,
+  },
+};
+
+export const sectionList: SectionConfig[] = [sections.cyp, sections['early-cancer']];

--- a/src/pages/Fingertips/Fingertips.tsx
+++ b/src/pages/Fingertips/Fingertips.tsx
@@ -3,8 +3,14 @@ import { Box, CircularProgress } from '@mui/material';
 import HeaderContainer from '../Fingertips/components/HeaderBanner/HeaderContainer';
 import ChartPanel from './components/ChartPanel/ChartPanel';
 import { useNHSData } from '../../context/FingertipsContext';
+import { SectionConfig } from '../../config/sections';
+import { colors } from '../../theme';
 
-const Fingertips: React.FC = () => {
+interface FingertipsProps {
+  section: SectionConfig;
+}
+
+const Fingertips: React.FC<FingertipsProps> = ({ section }) => {
   const { loading, error } = useNHSData();
 
   if (loading) {
@@ -12,13 +18,13 @@ const Fingertips: React.FC = () => {
       <Box
         sx={{
           minHeight: '100vh',
-          backgroundColor: '#f0e0fb',
+          backgroundColor: section.backgroundColor,
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
         }}
       >
-        <CircularProgress sx={{ color: '#7b2cbf' }} />
+        <CircularProgress sx={{ color: colors.secondary.purple }} />
       </Box>
     );
   }
@@ -28,7 +34,7 @@ const Fingertips: React.FC = () => {
       <Box
         sx={{
           minHeight: '100vh',
-          backgroundColor: '#f0e0fb',
+          backgroundColor: section.backgroundColor,
           display: 'flex',
           justifyContent: 'center',
           alignItems: 'center',
@@ -51,7 +57,7 @@ const Fingertips: React.FC = () => {
           xs: 'auto',
           lg: '100vh',
         },
-        backgroundColor: '#f0e0fb',
+        backgroundColor: section.backgroundColor,
         display: 'flex',
         flexDirection: 'column',
         overflow: {
@@ -60,7 +66,7 @@ const Fingertips: React.FC = () => {
         },
       }}
     >
-      <HeaderContainer />
+      <HeaderContainer section={section} />
       <Box
         sx={{
           padding: {

--- a/src/pages/Fingertips/components/HeaderBanner/HeaderContainer.tsx
+++ b/src/pages/Fingertips/components/HeaderBanner/HeaderContainer.tsx
@@ -32,7 +32,11 @@ const HeaderContainer: React.FC<HeaderContainerProps> = ({ section }) => {
         }}
       >
         <Logo />
-        <TitleText mainTitle={section.mainTitle} subtitle={section.subtitle} />
+        <TitleText
+          mainTitle={section.mainTitle}
+          subtitle={section.subtitle}
+          workInProgress={section.id === 'early-cancer'}
+        />
         <SectionNav activeSectionId={section.id} />
         <DashboardInfoTooltip />
       </Box>

--- a/src/pages/Fingertips/components/HeaderBanner/HeaderContainer.tsx
+++ b/src/pages/Fingertips/components/HeaderBanner/HeaderContainer.tsx
@@ -3,10 +3,15 @@ import { Box } from '@mui/material';
 import Logo from './components/Logo';
 import TitleText from './components/TitleText';
 import DashboardInfoTooltip from './components/DashboardInfoTooltip';
+import SectionNav from './components/SectionNav';
 import { colors } from '../../../../theme';
+import { SectionConfig } from '../../../../config/sections';
 
+interface HeaderContainerProps {
+  section: SectionConfig;
+}
 
-const HeaderContainer: React.FC = () => {
+const HeaderContainer: React.FC<HeaderContainerProps> = ({ section }) => {
   return (
     <Box
       sx={{
@@ -27,7 +32,8 @@ const HeaderContainer: React.FC = () => {
         }}
       >
         <Logo />
-        <TitleText />
+        <TitleText mainTitle={section.mainTitle} subtitle={section.subtitle} />
+        <SectionNav activeSectionId={section.id} />
         <DashboardInfoTooltip />
       </Box>
     </Box>

--- a/src/pages/Fingertips/components/HeaderBanner/components/SectionNav.tsx
+++ b/src/pages/Fingertips/components/HeaderBanner/components/SectionNav.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Box } from '@mui/material';
+import { Link } from 'react-router-dom';
+import { sectionList, SectionId } from '../../../../../config/sections';
+import { typography } from '../../../../../theme';
+
+interface SectionNavProps {
+  activeSectionId: SectionId;
+}
+
+const SectionNav: React.FC<SectionNavProps> = ({ activeSectionId }) => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.25rem',
+      }}
+    >
+      {sectionList.map((section) => {
+        const isActive = section.id === activeSectionId;
+        return (
+          <Link
+            key={section.id}
+            to={section.path}
+            style={{ textDecoration: 'none' }}
+          >
+            <Box
+              component="span"
+              sx={{
+                display: 'inline-block',
+                padding: '0.5rem 1rem',
+                borderRadius: '0.375rem',
+                fontFamily: typography.fonts.body,
+                fontSize: '13px',
+                fontWeight: isActive
+                  ? typography.fontWeights.semibold
+                  : typography.fontWeights.medium,
+                color: isActive ? section.accentColor : 'rgba(255, 255, 255, 0.6)',
+                backgroundColor: isActive
+                  ? `rgba(${section.accentColorRgb}, 0.25)`
+                  : 'rgba(255, 255, 255, 0.1)',
+                border: isActive
+                  ? `1px solid rgba(${section.accentColorRgb}, 0.6)`
+                  : '1px solid transparent',
+                transition: 'background-color 150ms ease',
+                whiteSpace: 'nowrap',
+                '&:hover': {
+                  backgroundColor: isActive
+                    ? `rgba(${section.accentColorRgb}, 0.3)`
+                    : 'rgba(255, 255, 255, 0.15)',
+                },
+              }}
+            >
+              {section.navLabel}
+            </Box>
+          </Link>
+        );
+      })}
+    </Box>
+  );
+};
+
+export default SectionNav;

--- a/src/pages/Fingertips/components/HeaderBanner/components/TitleText.tsx
+++ b/src/pages/Fingertips/components/HeaderBanner/components/TitleText.tsx
@@ -5,11 +5,13 @@ import { colors, typography } from '../../../../../theme';
 interface TitleTextProps {
   mainTitle?: string;
   subtitle?: string;
+  workInProgress?: boolean;
 }
 
-const TitleText: React.FC<TitleTextProps> = ({ 
+const TitleText: React.FC<TitleTextProps> = ({
   mainTitle = "Edge Health",
-  subtitle = "Children & Young People Health"
+  subtitle = "Children & Young People Health",
+  workInProgress = false
 }) => {
   return (
     <Box
@@ -50,6 +52,27 @@ const TitleText: React.FC<TitleTextProps> = ({
           </Typography>
         )}
       </Box>
+      {workInProgress && (
+        <Box
+          component="span"
+          sx={{
+            ml: '1rem',
+            px: '0.625rem',
+            py: '0.25rem',
+            borderRadius: '0.375rem',
+            backgroundColor: colors.secondary.orange,
+            color: colors.primary.darkBlue,
+            fontFamily: typography.fonts.body,
+            fontSize: typography.fontSizes.sm,
+            fontWeight: typography.fontWeights.bold,
+            textTransform: 'uppercase',
+            letterSpacing: '0.05em',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          🚧 Work in Progress
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -15,6 +15,8 @@ export const colors = {
     white: '#ffffff',
     grey: '#575756',
     lightPink: '#f0e0fb',
+    lightCyan: '#d9f0f1',
+    purple: '#7b2cbf',
   },
 
   // Semantic colors (for common use cases)
@@ -47,6 +49,8 @@ export const colorsRGB: Record<string, string> = {
   white: '0, 0, 0',
   grey: '87, 87, 86',
   lightPink: '240, 224, 251',
+  lightCyan: '217, 240, 241',
+  purple: '123, 44, 191',
 };
 
 export default colors;


### PR DESCRIPTION
- New page with the same charts, data, and layout as the existing CYP page, but different title and background colour
- 2 routes using `react-router-dom`: `/cyp` and `/early-cancer`
- added section navigator to the header
- added section config file to hold per-page settings
- work in progress flag for early cancer page

<img width="2248" height="1294" alt="image" src="https://github.com/user-attachments/assets/118a8937-bcfe-48a9-930b-766f9a59b70c" />