### PR TITLE
PBD-8: wire category filter to app routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,21 +9,30 @@ const basename = process.env.PUBLIC_URL || '/';
 
 function App() {
   return (
-    <FingertipsProvider>
-      <BrowserRouter basename={basename}>
-        <div className="App">
-          <Routes>
-            <Route path="/" element={<Navigate to="/cyp" replace />} />
-            <Route path="/cyp" element={<Fingertips section={sections.cyp} />} />
-            <Route
-              path="/early-cancer"
-              element={<Fingertips section={sections['early-cancer']} />}
-            />
-            <Route path="*" element={<Navigate to="/cyp" replace />} />
-          </Routes>
-        </div>
-      </BrowserRouter>
-    </FingertipsProvider>
+    <BrowserRouter basename={basename}>
+      <div className="App">
+        <Routes>
+          <Route path="/" element={<Navigate to="/cyp" replace />} />
+          <Route
+            path="/cyp"
+            element={
+              <FingertipsProvider category={sections.cyp.category}>
+                <Fingertips section={sections.cyp} />
+              </FingertipsProvider>
+            }
+          />
+          <Route
+            path="/early-cancer"
+            element={
+              <FingertipsProvider category={sections['early-cancer'].category}>
+                <Fingertips section={sections['early-cancer']} />
+              </FingertipsProvider>
+            }
+          />
+          <Route path="*" element={<Navigate to="/cyp" replace />} />
+        </Routes>
+      </div>
+    </BrowserRouter>
   );
 }
 

--- a/src/config/sections.ts
+++ b/src/config/sections.ts
@@ -2,9 +2,13 @@ import { colors, colorsRGB } from '../theme/colors';
 
 export type SectionId = 'cyp' | 'early-cancer';
 
+// API `category` query param accepted by the /indicators endpoint.
+export type SectionCategory = 'CYP' | 'EarlyCancer';
+
 export interface SectionConfig {
   id: SectionId;
   path: string;
+  category: SectionCategory;
   navLabel: string;
   mainTitle: string;
   subtitle: string;
@@ -17,6 +21,7 @@ export const sections: Record<SectionId, SectionConfig> = {
   cyp: {
     id: 'cyp',
     path: '/cyp',
+    category: 'CYP',
     navLabel: 'Children & Young People',
     mainTitle: 'Edge Health',
     subtitle: 'Children & Young People Health',
@@ -27,6 +32,7 @@ export const sections: Record<SectionId, SectionConfig> = {
   'early-cancer': {
     id: 'early-cancer',
     path: '/early-cancer',
+    category: 'EarlyCancer',
     navLabel: 'Early Cancer Diagnosis',
     mainTitle: 'Edge Health',
     subtitle: 'Early Cancer Diagnosis',

--- a/src/context/FingertipsContext.tsx
+++ b/src/context/FingertipsContext.tsx
@@ -21,7 +21,7 @@ export interface NHSContextType {
 
 const NHSContext = createContext<NHSContextType | undefined>(undefined);
 
-export const FingertipsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+export const FingertipsProvider: React.FC<{ children: React.ReactNode; category: string }> = ({ children, category }) => {
   const [data, setData] = useState<NHSDataPoint[]>([]);
   const [selectedRegion, setSelectedRegion] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -33,7 +33,7 @@ export const FingertipsProvider: React.FC<{ children: React.ReactNode }> = ({ ch
     setError(false);
     setGameVisible(true);
     try {
-      const response = await apiService.getIndicatorData();
+      const response = await apiService.getIndicatorData(category);
       
       const transformedData: NHSDataPoint[] = response.data.map((item: any) => ({
         area_code: item.area_code,
@@ -42,7 +42,7 @@ export const FingertipsProvider: React.FC<{ children: React.ReactNode }> = ({ ch
         indicator_name: item.indicator_name,
         time_period: item.time_period,
         time_period_sortable: item.time_period_sortable,
-        value_note: item.value_note || 'Other', 
+        value_note: item.value_note || 'Other',
       }));
       
       setData(transformedData);
@@ -56,7 +56,7 @@ export const FingertipsProvider: React.FC<{ children: React.ReactNode }> = ({ ch
 
   useEffect(() => {
     loadData();
-  }, []);
+  }, [category]);
 
   return (
     <NHSContext.Provider value={{
@@ -67,8 +67,7 @@ export const FingertipsProvider: React.FC<{ children: React.ReactNode }> = ({ ch
       setSelectedRegion,
     }}>
       {children}
-      
-      </NHSContext.Provider>
+    </NHSContext.Provider>
   );
 };
 

--- a/src/services/fingertipsApi.ts
+++ b/src/services/fingertipsApi.ts
@@ -35,8 +35,10 @@ export interface IndicatorMetadataResponse {
   indicators: IndicatorMetadata[];
 }
 
-const fetchFromApi = async <T>(endpoint: string): Promise<T> => {
-  const url = `${API_BASE_URL}${endpoint}?code=${API_KEY}`;
+const fetchFromApi = async <T>(endpoint: string, category?: string): Promise<T> => {
+  const url = category
+    ? `${API_BASE_URL}${endpoint}?code=${API_KEY}&category=${category}`
+    : `${API_BASE_URL}${endpoint}?code=${API_KEY}`;
   
   try {
     const response = await fetch(url, {
@@ -57,8 +59,8 @@ const fetchFromApi = async <T>(endpoint: string): Promise<T> => {
 };
 
 export const apiService = {
-  getIndicatorData: (): Promise<IndicatorDataResponse> => 
-    fetchFromApi('/indicators'),
+  getIndicatorData: (category: string): Promise<IndicatorDataResponse> => 
+    fetchFromApi('/indicators', category),
 
   getIndicatorMetadata: (): Promise<IndicatorMetadataResponse> => 
     fetchFromApi('/indicator_metadata'),


### PR DESCRIPTION
## Purpose
Wire the `?category=` API parameter to the app routing so the correct category filter is automatically passed when loading the dashboard.

## Changes
- `fingertipsApi.ts` — `fetchFromApi` now accepts an optional category 
  parameter and conditionally appends `&category=` to the URL. 
  `getIndicatorData` updated to require a category argument.
- `FingertipsContext.tsx` — `FingertipsProvider` now accepts a `category` 
  prop and passes it through to `getIndicatorData`. `useEffect` re-runs 
  if category changes.
- `App.tsx` — passes `category="CYP"` into `FingertipsProvider` for the 
  existing page.