### PR TITLE
Fix SPA deep-link 404s on GitHub Pages

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Fingertips Dashboard</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License — https://github.com/rafgraph/spa-github-pages
+      // Redirects a deep-link 404 to index.html, preserving the path as a query
+      // string so the app can restore it. pathSegmentsToKeep = 1 keeps the
+      // "/fingertips-dashboard" project base path on github.io.
+      var pathSegmentsToKeep = 1;
+
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+    </script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -25,6 +25,24 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>React App</title>
+    <script type="text/javascript">
+      // Single Page Apps for GitHub Pages
+      // MIT License — https://github.com/rafgraph/spa-github-pages
+      // Decodes the path that 404.html stashed in the query string, restoring
+      // the real URL before React Router initialises.
+      (function (l) {
+        if (l.search[1] === '/') {
+          var decoded = l.search
+            .slice(1)
+            .split('&')
+            .map(function (s) {
+              return s.replace(/~and~/g, '&');
+            })
+            .join('?');
+          window.history.replaceState(null, null, l.pathname.slice(0, -1) + decoded + l.hash);
+        }
+      })(window.location);
+    </script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>


### PR DESCRIPTION
## Problem
Refreshing or pasting a route URL (e.g. `/fingertips-dashboard/early-cancer`) returns a 404. In-app navigation works because routing is client-side, but GitHub Pages looks for a static file at that path, doesn't find one, and 404s before React Router can handle it.

## Fix
Adds the standard [spa-github-pages](https://github.com/rafgraph/spa-github-pages) redirect:
- **`public/404.html`** (new) — GH Pages serves this for any unmatched path; it stashes the path in a query string and redirects to the app root.
- **`public/index.html`** — a small snippet restores the real URL via `history.replaceState` before React Router initialises.

`pathSegmentsToKeep = 1` preserves the `/fingertips-dashboard` project-page base path.

## Result
`…/fingertips-dashboard/early-cancer` now resolves on refresh/paste. Verified `npm run build` emits `build/404.html` and both scripts survive minification. Behaviour only manifests on GitHub Pages (the dev server already handles deep links), so confirm on the live site after deploy.