### PR TITLE
Align API client with NHS RESTful standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,22 @@ https://get-fingertips-data-akateqfdbxepgcht.uksouth-01.azurewebsites.net/api
 
 **Authentication:** API key passed as a `code` query parameter.
 
+**Versioning:** All routes are served under a `/v1` prefix.
+
 **Endpoints:**
 
-| Endpoint               | Description                        |
-|------------------------|------------------------------------|
-| `/indicators`          | Fetches all health indicator data  |
-| `/indicator_metadata`  | Retrieves indicator metadata       |
+| Endpoint                    | Description                                    |
+|-----------------------------|------------------------------------------------|
+| `/v1/indicators`            | Health indicator data by `category` (paginated)|
+| `/v1/indicators/{id}`       | All rows for a single indicator                |
+| `/v1/indicator-metadata`    | Indicator metadata (id + name)                 |
+| `/v1/genomics`              | Genomics metrics (paginated)                   |
+| `/v1/health`                | Health check                                   |
+
+Collection endpoints are paginated via `page` and `page_size` query params (max
+`page_size` 5000). The API client (`fingertipsApi.ts`) pages through automatically
+and concatenates results. Errors are returned as RFC 7807 `application/problem+json`
+with a `correlationId` for support.
 
 The API service lives in [`src/services/fingertipsApi.ts`](src/services/fingertipsApi.ts). API base URL and key are configured via environment variables:
 
@@ -49,12 +59,17 @@ In production, these are injected from GitHub Secrets during the CI build.
 
 ## Data Structure
 
-The API returns data in the following shape:
+The `/v1/indicators` endpoint returns a paginated shape:
 
 ```typescript
 {
-  total_records: number;
   data: IndicatorData[];
+  pagination: {
+    page: number;
+    page_size: number;
+    total_records: number;
+    total_pages: number;
+  };
 }
 ```
 

--- a/src/services/fingertipsApi.ts
+++ b/src/services/fingertipsApi.ts
@@ -1,6 +1,9 @@
 const API_BASE_URL = process.env.REACT_APP_DASH_API_BASE_URL;
 const API_KEY = process.env.REACT_APP_DASH_API_KEY;
 
+// API version prefix. The backend serves all routes under /api/v1/...
+const API_VERSION = 'v1';
+
 export interface IndicatorData {
   indicator_id: number;
   indicator_name: string;
@@ -21,9 +24,21 @@ export interface IndicatorData {
   time_period_range: string;
 }
 
-export interface IndicatorDataResponse {
+export interface Pagination {
+  page: number;
+  page_size: number;
   total_records: number;
+  total_pages: number;
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  pagination: Pagination;
+}
+
+export interface IndicatorDataResponse {
   data: IndicatorData[];
+  pagination: Pagination;
 }
 
 export interface IndicatorMetadata {
@@ -35,33 +50,89 @@ export interface IndicatorMetadataResponse {
   indicators: IndicatorMetadata[];
 }
 
-const fetchFromApi = async <T>(endpoint: string, category?: string): Promise<T> => {
-  const url = category
-    ? `${API_BASE_URL}${endpoint}?code=${API_KEY}&category=${category}`
-    : `${API_BASE_URL}${endpoint}?code=${API_KEY}`;
-  
+// RFC 7807 problem detail returned by the API on error.
+export interface ProblemDetail {
+  type?: string;
+  title: string;
+  status: number;
+  detail: string;
+  instance?: string;
+  correlationId?: string;
+}
+
+// How many records to request per page when paging through a collection.
+const PAGE_SIZE = 5000;
+
+const buildUrl = (endpoint: string, params: Record<string, string> = {}): string => {
+  const search = new URLSearchParams({ code: API_KEY ?? '', ...params });
+  return `${API_BASE_URL}/${API_VERSION}${endpoint}?${search.toString()}`;
+};
+
+const fetchJson = async <T>(url: string): Promise<T> => {
   try {
     const response = await fetch(url, {
-      headers: {
-        'Content-Type': 'application/json',
-      },
+      headers: { 'Content-Type': 'application/json' },
     });
-    
+
     if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+      // The API returns RFC 7807 problem+json on error; surface its detail if present.
+      let message = `HTTP error! status: ${response.status}`;
+      try {
+        const problem = (await response.json()) as ProblemDetail;
+        if (problem?.detail) {
+          message = `${problem.title ?? 'Error'}: ${problem.detail}`;
+          if (problem.correlationId) message += ` (correlationId: ${problem.correlationId})`;
+        }
+      } catch {
+        // response had no JSON body; keep the generic message
+      }
+      throw new Error(message);
     }
 
-    return await response.json();
+    return (await response.json()) as T;
   } catch (error) {
-    console.error(`API request failed for ${endpoint}:`, error instanceof Error ? error.message : 'Unknown error');
+    console.error(`API request failed for ${url}:`, error instanceof Error ? error.message : 'Unknown error');
     throw error;
   }
 };
 
-export const apiService = {
-  getIndicatorData: (category: string): Promise<IndicatorDataResponse> => 
-    fetchFromApi('/indicators', category),
+/**
+ * Fetch every page of a paginated collection endpoint and concatenate the results.
+ * The backend caps page_size, so large collections come back across several pages.
+ */
+const fetchAllPages = async (
+  endpoint: string,
+  params: Record<string, string> = {}
+): Promise<IndicatorData[]> => {
+  const all: IndicatorData[] = [];
+  let page = 1;
+  let totalPages = 1;
 
-  getIndicatorMetadata: (): Promise<IndicatorMetadataResponse> => 
-    fetchFromApi('/indicator_metadata'),
+  do {
+    const url = buildUrl(endpoint, { ...params, page: String(page), page_size: String(PAGE_SIZE) });
+    const response = await fetchJson<PaginatedResponse<IndicatorData>>(url);
+    all.push(...response.data);
+    totalPages = response.pagination?.total_pages ?? 1;
+    page += 1;
+  } while (page <= totalPages);
+
+  return all;
+};
+
+export const apiService = {
+  getIndicatorData: async (category: string): Promise<IndicatorDataResponse> => {
+    const data = await fetchAllPages('/indicators', { category });
+    return {
+      data,
+      pagination: {
+        page: 1,
+        page_size: data.length,
+        total_records: data.length,
+        total_pages: 1,
+      },
+    };
+  },
+
+  getIndicatorMetadata: (): Promise<IndicatorMetadataResponse> =>
+    fetchJson<IndicatorMetadataResponse>(buildUrl('/indicator-metadata')),
 };


### PR DESCRIPTION
Updates the dashboard's API client to match the backend changes just merged in `dash-api-function` (NHS RESTful API standards).

## Changes
- **Versioned routes**: client now calls `/v1/*` with consistent naming — `/v1/indicators`, `/v1/indicators/{id}`, `/v1/indicator-metadata`.
- **Pagination**: `getIndicatorData` pages through collection endpoints automatically (`page`/`page_size`, max 5000) and concatenates results. `FingertipsContext` was untouched since it still receives all rows via `response.data`.
- **RFC 7807 errors**: parses `application/problem+json` and surfaces `title: detail (correlationId: ...)`.
- **README**: updated endpoints table, pagination note, and response shape.

## Verification
- `tsc --noEmit` passes.
- Production build (`CI=false`, matching the deploy workflow) succeeds. Remaining eslint warnings are pre-existing and unrelated to this change.

## Deploy note
Backend `/v1` routes are already merged/deployed. Merging this to `master` triggers the GitHub Pages deploy and cuts the live dashboard over to `/v1`.