### PR TITLE
Fix England Average to use actual England value

### DIFF
--- a/src/pages/Fingertips/hooks/useFilter.ts
+++ b/src/pages/Fingertips/hooks/useFilter.ts
@@ -112,19 +112,38 @@ export const useFilter = () => {
 
   const averageValue = useMemo(() => {
     if (!selectedMetric || !selectedYear) return undefined;
-    
-    const filteredData = data.filter(item => 
+
+    const filteredData = data.filter(item =>
       item.indicator_name === selectedMetric &&
       item.time_period === selectedYear &&
       item.value !== undefined &&
       item.value !== null &&
       !isNaN(item.value)
     );
-    
+
     if (filteredData.length === 0) return undefined;
-    
-    const sum = filteredData.reduce((acc, item) => acc + item.value, 0);
-    return sum / filteredData.length;
+
+    // Prefer the actual England value from the data (a population-weighted rate)
+    // over a simple mean of the ICB values. The England row is published as
+    // area_code E92000001 / area_name "England".
+    const englandRow = filteredData.find(item =>
+      item.area_code === 'E92000001' ||
+      item.area_name?.toLowerCase() === 'england'
+    );
+
+    if (englandRow) return englandRow.value;
+
+    // Fallback: no England row present, so approximate with a simple mean of the
+    // remaining area values. Note this is unweighted and only an approximation.
+    const icbData = filteredData.filter(item =>
+      item.area_code !== 'E92000001' &&
+      item.area_name?.toLowerCase() !== 'england'
+    );
+
+    if (icbData.length === 0) return undefined;
+
+    const sum = icbData.reduce((acc, item) => acc + item.value, 0);
+    return sum / icbData.length;
   }, [data, selectedMetric, selectedYear]);
 
   const selectedMetricDetails = selectedMetric 


### PR DESCRIPTION
## Problem

The map sidebar's **England Average** was computed as a simple arithmetic mean of every ICB's value (`useFilter.ts`), producing an inflated, unweighted figure. For urgent suspected cancer referrals (2024/25) it showed **5085.3** instead of the true England rate of **4899.2**.

The real England figure is a population-weighted rate (total count ÷ total denominator) already published in the dataset as the `E92000001` / "England" row — the same row the "Comparison to England" line chart uses correctly.

## Fix

In `src/pages/Fingertips/hooks/useFilter.ts`, `averageValue` now:

1. Uses the actual **England row** (`E92000001` / area_name "England") when present — the correct weighted value.
2. Falls back to a simple mean over **ICB rows only** (excluding any England row) when no England row exists. The frontend data carries no count/denominator, so a true weighted average isn't possible client-side; this fallback is an unweighted approximation used only when the published England value is missing.
3. Returns `undefined` when there's no data, so the sidebar hides the average.

## Testing

- Verified the England row exists in the data and matches the SQL query value (4899.2) and the England line in the comparison chart.