### PR TITLE
Remove 'Work in Progress' badge

### DIFF
--- a/src/pages/Fingertips/components/HeaderBanner/HeaderContainer.tsx
+++ b/src/pages/Fingertips/components/HeaderBanner/HeaderContainer.tsx
@@ -36,7 +36,6 @@ const HeaderContainer: React.FC<HeaderContainerProps> = ({ section }) => {
         <TitleText
           mainTitle={section.mainTitle}
           subtitle={section.subtitle}
-          workInProgress={section.id === 'early-cancer'}
         />
         <SectionNav activeSectionId={section.id} />
         <DashboardInfoTooltip />

--- a/src/pages/Fingertips/components/HeaderBanner/components/TitleText.tsx
+++ b/src/pages/Fingertips/components/HeaderBanner/components/TitleText.tsx
@@ -5,13 +5,11 @@ import { colors, typography } from '../../../../../theme';
 interface TitleTextProps {
   mainTitle?: string;
   subtitle?: string;
-  workInProgress?: boolean;
 }
 
 const TitleText: React.FC<TitleTextProps> = ({
   mainTitle = "Edge Health",
-  subtitle = "Children & Young People Health",
-  workInProgress = false
+  subtitle = "Children & Young People Health"
 }) => {
   return (
     <Box
@@ -54,27 +52,6 @@ const TitleText: React.FC<TitleTextProps> = ({
           </Typography>
         )}
       </Box>
-      {workInProgress && (
-        <Box
-          component="span"
-          sx={{
-            ml: '1rem',
-            px: '0.625rem',
-            py: '0.25rem',
-            borderRadius: '0.375rem',
-            backgroundColor: colors.secondary.orange,
-            color: colors.primary.darkBlue,
-            fontFamily: typography.fonts.body,
-            fontSize: typography.fontSizes.sm,
-            fontWeight: typography.fontWeights.bold,
-            textTransform: 'uppercase',
-            letterSpacing: '0.05em',
-            whiteSpace: 'nowrap',
-          }}
-        >
-          🚧 Work in Progress
-        </Box>
-      )}
     </Box>
   );
 };


### PR DESCRIPTION
## Summary

Removes the '🚧 Work in Progress' badge entirely.

- Removes the `workInProgress` prop and its conditional badge from `TitleText`.
- Removes the call site in `HeaderContainer` that enabled the badge for the `early-cancer` section.

## Notes

The `colors` and `typography` imports in `TitleText` remain in use elsewhere in the component, so no dangling imports.