### PR TITLE
PBD-36 Parallel page fetching and per-category client cache

### DIFF
--- a/src/pages/Fingertips/hooks/useFilter.ts
+++ b/src/pages/Fingertips/hooks/useFilter.ts
@@ -52,8 +52,12 @@ export const useFilter = () => {
   }, [data, selectedMetric]);
 
   useEffect(() => {
-    if (availableMetrics.length > 0 && !selectedMetric) {
+    if (availableMetrics.length === 0) return;
+    // Also covers a selection carried over from another section's dataset
+    // (the component is not remounted when switching between sections).
+    if (!selectedMetric || !availableMetrics.some(m => m.id === selectedMetric)) {
       setSelectedMetric(availableMetrics[0].id);
+      setSelectedYear(null);
     }
   }, [availableMetrics, selectedMetric]);
 

--- a/src/services/fingertipsApi.ts
+++ b/src/services/fingertipsApi.ts
@@ -96,41 +96,62 @@ const fetchJson = async <T>(url: string): Promise<T> => {
   }
 };
 
+const fetchPage = (
+  endpoint: string,
+  params: Record<string, string>,
+  page: number
+): Promise<PaginatedResponse<IndicatorData>> =>
+  fetchJson<PaginatedResponse<IndicatorData>>(
+    buildUrl(endpoint, { ...params, page: String(page), page_size: String(PAGE_SIZE) })
+  );
+
 /**
  * Fetch every page of a paginated collection endpoint and concatenate the results.
  * The backend caps page_size, so large collections come back across several pages.
+ * Page 1 tells us the total page count; the remaining pages are fetched in parallel.
  */
 const fetchAllPages = async (
   endpoint: string,
   params: Record<string, string> = {}
 ): Promise<IndicatorData[]> => {
-  const all: IndicatorData[] = [];
-  let page = 1;
-  let totalPages = 1;
+  const first = await fetchPage(endpoint, params, 1);
+  const totalPages = first.pagination?.total_pages ?? 1;
+  if (totalPages <= 1) return first.data;
 
-  do {
-    const url = buildUrl(endpoint, { ...params, page: String(page), page_size: String(PAGE_SIZE) });
-    const response = await fetchJson<PaginatedResponse<IndicatorData>>(url);
-    all.push(...response.data);
-    totalPages = response.pagination?.total_pages ?? 1;
-    page += 1;
-  } while (page <= totalPages);
-
-  return all;
+  const rest = await Promise.all(
+    Array.from({ length: totalPages - 1 }, (_, i) => fetchPage(endpoint, params, i + 2))
+  );
+  return first.data.concat(...rest.map((response) => response.data));
 };
 
+// Datasets already downloaded this session, keyed by category, so switching
+// sections never re-fetches. Stores the in-flight promise (not the resolved
+// value) so concurrent callers for the same category share a single download.
+const indicatorDataCache = new Map<string, Promise<IndicatorDataResponse>>();
+
 export const apiService = {
-  getIndicatorData: async (category: string): Promise<IndicatorDataResponse> => {
-    const data = await fetchAllPages('/indicators', { category });
-    return {
-      data,
-      pagination: {
-        page: 1,
-        page_size: data.length,
-        total_records: data.length,
-        total_pages: 1,
-      },
-    };
+  getIndicatorData: (category: string): Promise<IndicatorDataResponse> => {
+    const cached = indicatorDataCache.get(category);
+    if (cached) return cached;
+
+    const request = (async (): Promise<IndicatorDataResponse> => {
+      const data = await fetchAllPages('/indicators', { category });
+      return {
+        data,
+        pagination: {
+          page: 1,
+          page_size: data.length,
+          total_records: data.length,
+          total_pages: 1,
+        },
+      };
+    })();
+
+    // Don't cache failures — a retry (e.g. remounting the section) should hit the network again.
+    request.catch(() => indicatorDataCache.delete(category));
+
+    indicatorDataCache.set(category, request);
+    return request;
   },
 
   getIndicatorMetadata: (): Promise<IndicatorMetadataResponse> =>


### PR DESCRIPTION
Speed up initial data load and make section switching instant. Two commits:

1. **Parallel page fetching** (`src/services/fingertipsApi.ts`) `fetchAllPages` previously awaited each page sequentially in a do/while loop. It now fetches page 1, reads `total_pages`, then requests all remaining pages concurrently with `Promise.all`. Load time for a multi-page category drops from the *sum* of all page times to page 1 + the slowest remaining page.

2. **Per-category client-side cache** (`src/services/fingertipsApi.ts`) `getIndicatorData` caches the in-flight promise per category in a module-level Map, so switching between /cyp and /early-cancer never re-downloads the dataset (zero network requests), and concurrent callers share a single download. Failed requests are evicted so a retry hits the network again.

   Plus a bug fix this exposed (`src/pages/Fingertips/hooks/useFilter.ts`): with instant switching the ChartPanel is no longer remounted, so the previous section's selected metric could leak into a dataset that doesn't contain it, leaving the metric dropdown and time slider empty. The selection now resets whenever it's absent from the current dataset's metrics.

## Why

The dashboard downloaded the full dataset page-by-page sequentially on every page load, then threw it away and re-downloaded it on every section switch. This builds on step 2 (API response caching, dash-api-function #9): cache misses are absorbed server-side, and `Cache-Control: public, max-age=86400` means the browser cache layers on top of the client cache.
